### PR TITLE
Update tutorial.md and code from tutorial/ for new delorian.js

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -11,8 +11,8 @@ First of all, let's create the DOM (view) we'll need.
     <script src="https://cdn.rawgit.com/deloreanjs/delorean/master/dist/delorean.min.js"></script>
   </head>
   <body>
-    <ul id="list"></ul>
     <button id="addItem">Add Random Item</button>
+    <ul id="list"></ul>
 
     <script src="js/app.js"></script>
   </body>
@@ -90,7 +90,7 @@ with arguments.
 Also you have to call `this.emit('change')` when you update your data.
 
 ```javascript
-var MyAppStore = DeLorean.Flux.createStore({
+var myStore = DeLorean.Flux.createStore({
   list: [],
   actions: {
     // Remember the `dispatch('addItem')`
@@ -103,8 +103,9 @@ var MyAppStore = DeLorean.Flux.createStore({
     this.emit('change');
   }
 });
-var myStore = new MyAppStore();
 ```
+
+Make sure you put this code before the one from step 2 though, because we were using `myStore` in creating the `MyAppDispatcher`, and that will keep a reference to the store internally.
 
 ### Step 4: Completing the Cycle: Views
 
@@ -117,7 +118,7 @@ var list = document.getElementById('list');
 myStore.onChange(function () {
   list.innerHTML = ''; // Best thing for this example.
 
-  myStore.store.list.forEach(function (item) {
+  myStore.list.forEach(function (item) {
     var listItem = document.createElement('li');
     listItem.innerHTML = item;
     list.appendChild(listItem);

--- a/examples/tutorial/index.html
+++ b/examples/tutorial/index.html
@@ -4,8 +4,8 @@
     <script src="http://rawgit.com/f/delorean/master/dist/delorean.min.js"></script>
   </head>
   <body>
-    <ul id="list"></ul>
     <button id="addItem">Add Random Item</button>
+    <ul id="list"></ul>
 
     <script src="js/app.js"></script>
   </body>

--- a/examples/tutorial/js/app.js
+++ b/examples/tutorial/js/app.js
@@ -9,7 +9,7 @@ var ActionCreator = {
   }
 };
 
-var MyAppStore = DeLorean.Flux.createStore({
+var myStore = DeLorean.Flux.createStore({
   list: [],
   actions: {
     // Remember the `dispatch('addItem')`
@@ -22,7 +22,6 @@ var MyAppStore = DeLorean.Flux.createStore({
     this.emit('change');
   }
 });
-var myStore = new MyAppStore();
 
 var MyAppDispatcher = DeLorean.Flux.createDispatcher({
   addItem: function (data) {
@@ -42,7 +41,7 @@ var list = document.getElementById('list');
 myStore.onChange(function () {
   list.innerHTML = ''; // Best thing for this example.
 
-  myStore.store.list.forEach(function (item) {
+  myStore.list.forEach(function (item) {
     var listItem = document.createElement('li');
     listItem.innerHTML = item;
     list.appendChild(listItem);


### PR DESCRIPTION
### Description

Related to issue https://github.com/deloreanjs/delorean/issues/90.

`tutorial.md` wasn't updated to the `delorian.js` version present in the cdn (it was updated from `0.8.3` where it was working accordingly). Also updated the code in `examples/tutorial/` to match the new `tutorial.md`.

### Another unsolved issue

Note that step 5 from the `tutorial.md` wasn't working correctly even with `delorean-0.8.3` which is released around the same time the file was written (end of September 2014). You can try it out and see it's producing results like:
```
ITEM: ITEM: ITEM: ITEM: ITEM: 0.5519198384135962
ITEM: ITEM: ITEM: ITEM: 0.014080600813031197
ITEM: ITEM: ITEM: 0.8087677867151797
ITEM: ITEM: 0.9754587386269122
ITEM: 0.560909275431186
```

I just started looking over flux, so best I can do it point it out, don't know a good fix for it.