### PR TITLE
Add a trigger mixin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "delorean",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "Flux Library",
   "main": "src/delorean.js",
   "scripts": {

--- a/src/delorean.js
+++ b/src/delorean.js
@@ -566,6 +566,21 @@
 
   // ## Built-in React Mixin
   DeLorean.Flux.mixins = {
+
+    // This mixin adds the this.trigger method to the component
+    // Components can then trigger actions in flux w/out watching stores and having their state
+    trigger: {
+
+      componentWillMount: function () {
+        this.__dispatcher = __findDispatcher(this);
+      },
+
+      trigger: function () {
+        this.__dispatcher.emit.apply(this.__dispatcher, arguments);
+      }
+    
+    },
+
     // It should be inserted to the React components which
     // used in Flux.
     // Simply `mixin: [Flux.mixins.storeListener]` will work.


### PR DESCRIPTION
this adds a new mixin to `DeLorean.Flux.mixins` called `trigger`.

Over time my team has found cases where it's useful to trigger changes in flux stores, but the component itself does not (and should not) re-render when the store changes. This is because a parent component is already watching changes, and will send it down props when it re-renders.

No breaking changes here. No existing code altered.

@f or @tommoor - not sure if either of you still use or care about this repo. But if I don't here objections in the next day or so, I'm gonna merge and publish.

